### PR TITLE
git clone: Increase history to 50

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,7 +54,7 @@
   git:
     repo: "{{ engelsystem_repo }}"
     dest: "{{ engelsystem_install_path }}"
-    depth: 1
+    depth: 50
     update: true
     version: "{{ engelsystem_version }}"
   register: git


### PR DESCRIPTION
This allows to select older commits without the task failing (because `force: yes` is not supplied).