### PR TITLE
chore(mysql_db): Ansible 2.10 compatibility for mysql_db

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -96,7 +96,7 @@
     - storage
 
 - name: Create MariaDB database
-  mysql_db:
+  community.mysql.mysql_db:
     name: "{{ engelsystem_mysql_database }}"
     encoding: "utf8"
   register: database_created


### PR DESCRIPTION
Since Ansible 2.10, `mysql_db` is no longer a part of Ansible. It can be obtained from the Ansible Galaxy collection `community.mysql`. Note that this change probably breaks compatibility with Ansible <= 2.8.